### PR TITLE
Updated inspect.getargspec to inspect.getfullargspec

### DIFF
--- a/tfa/optimisation.py
+++ b/tfa/optimisation.py
@@ -188,7 +188,8 @@ def calculate_fit_fractions(pdf, norm_sample):
     """
     import inspect
 
-    args, varargs, keywords, defaults = inspect.getargspec(pdf)
+    pdf_kwargs = inspect.getfullargspec(pdf)
+    args, defaults = pdf_kwargs.args, pdf_kwargs.defaults
     num_switches = 0
     if defaults:
         default_dict = dict(zip(args[-len(defaults) :], defaults))

--- a/tfa/toymc.py
+++ b/tfa/toymc.py
@@ -72,7 +72,8 @@ def run_toymc(pdf, phsp, size, maximum, chunk=200000, seed=None, components=True
         )
         return d, pdf(d)
 
-    args, varargs, keywords, defaults = inspect.getargspec(pdf)
+    pdf_kwargs = inspect.getfullargspec(pdf)
+    args, defaults = pdf_kwargs.args, pdf_kwargs.defaults
     num_switches = 0
     if defaults:
         default_dict = dict(zip(args[-len(defaults) :], defaults))


### PR DESCRIPTION
`inspect.getargspec` has been deprecated since python3.0.
Updated the code accordingly.